### PR TITLE
Fix eclipse 543528 

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -243,7 +243,6 @@ final class GtkApplication extends Application implements
     private int getWindowScale() {
         String type = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.application.type", ""));
         if ("FXCanvas".equals(type)) {
-            PlatformLogger logger = Logging.getJavaFXLogger();
             final int scale = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("org.eclipse.swt.internal.deviceZoom", 100));
             return scale / 100;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -234,23 +234,20 @@ final class GtkApplication extends Application implements
         @SuppressWarnings("removal")
         final boolean disableGrab = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("sun.awt.disablegrab") ||
                Boolean.getBoolean("glass.disableGrab"));
-        
-	int windowScale = getWindowScale();
+
+        int windowScale = getWindowScale();
 
         _init(eventProc, disableGrab, windowScale);
     }
 
     private int getWindowScale() {
         String type = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.application.type", ""));
-    	if ("FXCanvas".equals(type)) {
+        if ("FXCanvas".equals(type)) {
             PlatformLogger logger = Logging.getJavaFXLogger();
             final int scale = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("org.eclipse.swt.internal.deviceZoom", 100));
-            logger.warning("scale=" + scale);
-            System.out.println("====== SCALE " + scale);
             return scale / 100;
-    	}
-        System.out.println("====== SCALE FAILURE ===== ");
-    	return 1;
+        }
+        return 1;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -234,8 +234,23 @@ final class GtkApplication extends Application implements
         @SuppressWarnings("removal")
         final boolean disableGrab = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("sun.awt.disablegrab") ||
                Boolean.getBoolean("glass.disableGrab"));
+        
+	int windowScale = getWindowScale();
 
-        _init(eventProc, disableGrab);
+        _init(eventProc, disableGrab, windowScale);
+    }
+
+    private int getWindowScale() {
+        String type = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.application.type", ""));
+    	if ("FXCanvas".equals(type)) {
+            PlatformLogger logger = Logging.getJavaFXLogger();
+            final int scale = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("org.eclipse.swt.internal.deviceZoom", 100));
+            logger.warning("scale=" + scale);
+            System.out.println("====== SCALE " + scale);
+            return scale / 100;
+    	}
+        System.out.println("====== SCALE FAILURE ===== ");
+    	return 1;
     }
 
     @Override
@@ -282,7 +297,7 @@ final class GtkApplication extends Application implements
 
     private native void _terminateLoop();
 
-    private native void _init(long eventProc, boolean disableGrab);
+    private native void _init(long eventProc, boolean disableGrab, int windowScale);
 
     private native void _runLoop(Runnable launchable, boolean noErrorTrap);
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -165,7 +165,7 @@ JNIEXPORT jint JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1queryLibrary
  * Signature: ()V
  */
 JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
-  (JNIEnv * env, jobject obj, jlong handler, jboolean _disableGrab)
+  (JNIEnv * env, jobject obj, jlong handler, jboolean _disableGrab, jint windowScale)
 {
     (void)obj;
 
@@ -173,7 +173,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
     process_events_prev = (GdkEventFunc) handler;
     disableGrab = (gboolean) _disableGrab;
 
-    glass_gdk_x11_display_set_window_scale(gdk_display_get_default(), 1);
+    glass_gdk_x11_display_set_window_scale(gdk_display_get_default(), windowScale);
     gdk_event_handler_set(process_events, NULL, NULL);
 
     GdkScreen *default_gdk_screen = gdk_screen_get_default();


### PR DESCRIPTION
Porting https://github.com/Halliburton-Landmark/openjdk-jfx/pull/1 to 21.0.3

Creating an FXCanvas resets HiDPI scaling on GTK3
**Bug**: https://bugs.eclipse.org/bugs/show_bug.cgi?id=543528

**Analysis**:
Initialization of FXCanvas calls glass_gdk_x11_display_set_window_scale with the hardcoded scale of 1.
When HiDPI scaling is applied, this causes scaling reset.

**Fix**
The actual scaling for FXCanvas is now fetched from the variable org.eclipse.swt.internal.deviceZoom (set by SWT) and passed to glass_gdk_x11_display_set_window_scale using a new param in native method _init.